### PR TITLE
fix: return error when session not created

### DIFF
--- a/lib/wallaby/webdriver_client.ex
+++ b/lib/wallaby/webdriver_client.ex
@@ -23,7 +23,13 @@ defmodule Wallaby.WebdriverClient do
   def create_session(base_url, capabilities) do
     params = %{desiredCapabilities: capabilities}
 
-    request(:post, "#{base_url}session", params)
+    case request(:post, "#{base_url}session", params) do
+      {:ok, %{"status" => status} = nonzero_status_response} when status != 0 ->
+        {:error, nonzero_status_response}
+
+      response ->
+        response
+    end
   end
 
   @doc """


### PR DESCRIPTION
Will allow us to remove the `create_session_fn` override in director. Mentioned in [this scraping PR](https://github.com/TernSystems/director/pull/412#discussion_r1786859388)